### PR TITLE
e2e support added

### DIFF
--- a/app/files.json
+++ b/app/files.json
@@ -34,9 +34,12 @@
         "gulp/proxy.js",
         "gulp/server.js",
         "gulp/unit-tests.js",
+        "gulp/e2e-tests.js",
         "gulp/watch.js",
         "gulpfile.js",
         "karma.conf.js",
+        "protractor.conf.js",
+        "e2e/sample.e2e-spec.js",
         "package.json"
     ],
 

--- a/app/templates/e2e/sample.e2e-spec.js
+++ b/app/templates/e2e/sample.e2e-spec.js
@@ -1,0 +1,9 @@
+/*global browser*/
+
+describe('sample e2e test suite', function () {
+    'use strict';
+
+    it('sample e2e spec', function () {
+        browser.sleep(1000);
+    });
+});

--- a/app/templates/gulp/e2e-tests.js
+++ b/app/templates/gulp/e2e-tests.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var gulp = require('gulp');
+var $ = require('gulp-load-plugins')();
+
+gulp.task('test:e2e', function () {
+    return gulp.src(config.scripts.e2eSrc())
+        .pipe($.angularProtractor({
+            'configFile': 'protractor.conf.js',
+            'autoStartStopServer': true,
+            'debug': false
+        }))
+        .on('error', function(e) { throw e });
+});

--- a/app/templates/gulp/lib/config-factory.js
+++ b/app/templates/gulp/lib/config-factory.js
@@ -85,6 +85,9 @@ var configFactory = function (externalConfig) {
                     pathsBuilder.buildForTopLevelModules(
                         '{src}/{moduleFile}', '{src}/{moduleDir}/**/*.module.js', '{src}/{moduleDir}/**/!(*spec|*mock).js')
                 ]);
+            },
+            e2eSrc: function(){
+                return ['./e2e/*.e2e-spec.js'];
             }
         },
         i18n: {

--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -12,6 +12,7 @@
         "coveralls": "2.11.2",
         "del": "1.2.0",
         "gulp": "3.9.0",
+        "gulp-angular-protractor": "0.0.2",
         "gulp-concat": "2.6.0",
         "gulp-filter": "2.0.2",
         "gulp-flatten": "0.1.0",

--- a/app/templates/protractor.conf.js
+++ b/app/templates/protractor.conf.js
@@ -1,0 +1,10 @@
+exports.config = {
+
+    seleniumAddress: 'http://localhost:4444/wd/hub',
+    baseUrl: 'http://localhost:9000/',
+
+    jasmineNodeOpts: {
+        showColors: true,
+        isVerbose: true
+    }
+};

--- a/test/generator-app.spec.js
+++ b/test/generator-app.spec.js
@@ -20,6 +20,14 @@ describe('oasp:app', function () {
                 '.jshintrc'
             ]);
         });
+
+        it('creates files associated with e2e', function () {
+            assert.file([
+                'protractor.conf.js',
+                'e2e/sample.e2e-spec.js',
+                'gulp/e2e-tests.js'
+            ]);
+        });
     });
 
     describe('with simple module name', function () {


### PR DESCRIPTION
e2e support added
gulp-angular-protractor plugin used.
To run e2e use gulp test:e2e
Sample test: e2e/sample.e2e-spec.js
File name pattern accepted by test runner: ./e2e/*.e2e-spec.js
